### PR TITLE
Ignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ instance
 nohup.out
 .vagrant
 nosetests.xml
+/sandbox/

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ nohup.out
 .vagrant
 nosetests.xml
 /sandbox/
+/tags
+/TAGS


### PR DESCRIPTION
Ignore `sandbox/` folder (from outside `.gitignore` file). Ignore tags files (`tags` and `TAGS`) generated by `ctags`.