### PR TITLE
Fix database error when doing wouso setup

### DIFF
--- a/wouso/games/quiz/models.py
+++ b/wouso/games/quiz/models.py
@@ -117,9 +117,6 @@ class QuizGame(Game):
         super(QuizGame, self).__init__(*args, **kwargs)
 
 
-register_category(QuizGame.QPOOL_CATEGORY, QuizGame)
-
-
 class QuizUser(Player):
     """
      Extension of the User object, customized for quiz
@@ -146,6 +143,8 @@ class QuizUser(Player):
 
 
 Player.register_extension('quiz', QuizUser)
+
+register_category(QuizGame.QPOOL_CATEGORY, QuizGame)
 
 
 class UserToQuiz(models.Model):


### PR DESCRIPTION
When doing `./manage.py wousoctl --setup`, you would get an error such as this:

    django.db.utils.DatabaseError: no such table: config_settings

This is due to a rather nasty situation of loading some modules ahead of the others. As such proper database tables would not be created. This bug was introduced in commit 139da4ac23e2403edf85870fe1f4d310e0ee7234. It is caused by placing the `register_category()` call ahead of the definition of the `QuizUser` class. The bug is fixed by moving the call after the definition of the `QuizUser` class.