### PR TITLE
Add questions script

### DIFF
--- a/wouso/utils/add_questions.py
+++ b/wouso/utils/add_questions.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+
+# To test, run from parent folder using a command such as:
+# PYTHONPATH=../:. python utils/add_questions.py utils/sample-data/sample-questions.csv
+
+import sys
+import os
+import codecs
+
+# Setup Django environment.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "wouso.settings")
+
+from wouso.core.qpool.models import Question, Answer, Tag, Category
+from django.contrib.auth.models import User
+
+
+def add_question(question, answers, category=None, tags=None, file_tags=None):
+    """ Question is a dict with the following keys: text, endorsed_by, answer_type
+    [, proposed_by, active, type, code]
+    answers is a list of dicts with the following keys: text, correct [, explanation]
+    """
+    q = Question(**question)
+    q.save()
+
+    if tags:
+        for tag in tags:
+            q.tags.add(tag)
+        q.save()
+
+    if file_tags:
+        for tag_name in file_tags:
+            tag, created = Tag.objects.get_or_create(name=tag_name, category=category)
+            if created:
+                tag.save()
+                if category is not None:
+                    category.tag_set.add(tag)
+                    category.save()
+            q.tags.add(tag)
+        q.save()
+
+    if category is not None:
+        q.category = category
+        q.save()
+
+    for answer in answers:
+        a = Answer(question=q, **answer)
+        a.save()
+
+    return q
+
+
+def import_from_file(opened_file, proposed_by=None, endorsed_by=None, category=None, tags=None, all_active=False):
+    # read file and parse contents
+    a_saved = True
+    q_saved = True
+    a = {}
+    answers = []
+    q = {}
+    nr_correct = 0
+
+    nr_imported = 0
+
+
+    state = 'question'
+
+    for line in opened_file:
+        line = line.strip()
+        if not line:
+            continue
+
+        # parse line according to its beginning
+        # second condition (or ____) is for windows reasons
+        if line[0] == '?' or (ord(line[0]) == 239 and line[3] == '?'):
+            if not a_saved:
+                answers.append(a)
+                a_saved = True
+            if not q_saved:
+                if all_active is True:
+                    q['active'] = True
+                if endorsed_by is not None:
+                    q['endorsed_by'] = endorsed_by
+                if proposed_by is not None:
+                    q['proposed_by'] = proposed_by
+                if len(answers) == 0:
+                    q['answer_type'] = 'F'
+                elif nr_correct == 1:
+                    q['answer_type'] = 'R'
+                else:
+                    q['answer_type'] = 'C'
+                add(q, answers, category, tags, file_tags)
+                nr_imported += 1
+                q_saved = True
+                a_saved = True
+
+            state = 'question'
+            q = {}
+            file_tags = None
+            answers = []
+            nr_correct = 0
+            q_saved = False
+            s = line.split()
+
+            q['text'] = ' '.join(s[1:])
+
+        elif line == 'tags:':
+            continue
+
+        elif line.startswith('tags: '):
+            tags_line = line.split('tags: ')[1]
+            file_tags = tags_line.split()
+
+        elif line[0] == '-' or line[0] == '+':
+            if not a_saved:
+                answers.append(a)
+                a_saved = True
+
+            state = 'answer'
+            a = {}
+            a_saved = False
+            s = line.split()
+
+            if s[0] == '-':
+                a['correct'] = False
+            else:
+                a['correct'] = True
+                nr_correct += 1
+
+            a['text'] = ' '.join(s[1:])
+
+        else:
+            # continuation line
+            if state == 'question':
+                if q.has_key('text'):
+                    q['text'] += '\n' + line
+                else:
+                    q['text'] = line
+
+            else:
+                a['text'] += '\n' + line
+
+    if not a_saved:
+        answers.append(a)
+        a_saved = True
+    if not q_saved:
+        if all_active is True:
+            q['active'] = True
+        if endorsed_by is not None:
+            q['endorsed_by'] = endorsed_by
+        if proposed_by is not None:
+            q['proposed_by'] = proposed_by
+        if len(answers) == 0:
+            q['answer_type'] = 'F'
+        elif nr_correct == 1:
+            q['answer_type'] = 'R'
+        else:
+            q['answer_type'] = 'C'
+        add(q, answers, category, tags, file_tags)
+        nr_imported += 1
+
+    return nr_imported
+
+
+def main():
+
+    if len(sys.argv) != 4:
+        print 'Usage: add_questions.py <file> <proposed-by> <endorsed_by>'
+        sys.exit(1)
+
+    filename = sys.argv[1]
+    proposed_by_name = sys.argv[2]
+    endorsed_by_name = sys.argv[3]
+
+    try:
+        proposed_by = User.objects.get(username=proposed_by_name)
+    except Exception as e:
+        print e
+        print >>sys.stderr, "Proposed by user %s does not exist." %(proposed_by_name)
+        sys.exit(1)
+    if not proposed_by:
+        print >>sys.stderr, "Proposed by user %s does not exist." %(proposed_by_name)
+        sys.exit(1)
+
+    try:
+        endorsed_by = User.objects.get(username=endorsed_by_name)
+    except Exception as e:
+        print e
+        print >>sys.stderr, "Proposed by user %s does not exist." %(endorsed_by_name)
+        sys.exit(1)
+    if not endorsed_by:
+        print >>sys.stderr, "Proposed by user %s does not exist." %(endorsed_by_name)
+        sys.exit(1)
+
+    try:
+        f = codecs.open(filename, 'r', 'utf-8')
+    except:
+        print >>sys.stderr, "Cannot open file %s for reading questions." %(filename)
+        sys.exit(1)
+    #import_questions_from_file(f, proposed_by, endorsed_by)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/wouso/utils/sample-data/sample-questions.txt
+++ b/wouso/utils/sample-data/sample-questions.txt
@@ -1,0 +1,46 @@
+? Care dintre următoarele componente se află cel mai aproape de hardware în ierarhia de aplicații?
++ nucleul
+- shell-ul
+- compilatorul
+- browser-ul
+
+? Care din următoarele definesc un sistem de operare? (alegeți 2 variante)
++ nucleu
+- programe de bază
+- aplicații
+- utilizator
++ hardware
+
+? Care este rădăcina sistemului de operare, respectiv separatorul de cale pe un sistem de fișiere Linux?
++ /, respectiv /
+- root, respectiv /
+- start, respectiv :
+- \, respetiv /
+
+? Care sunt cele două argumente uzuale ale comenzii mount? (alegeți 2 variante)
++ un dispozitiv
++ un director
+- un nume de utilizator
+- un proces
+- o adresă de memorie
+
+? Care dintre următoarele sunt întotdeauna definite pentru un utilizator într-un sistem Linux?
++ uid
+- director home
+- grupuri secundare
+- parolă
+
+? Care dintre următoarele pot fi asociate în număr mai mare de 1 unui utilizator?
+- parole
+- directoare home
+- grupuri primare
++ grupuri secundare
+
+? În care dintre următoarele fișiere se găsesc informații legate de utilizatori? (alegeți 3 variante)
++ /etc/passwd
++ /etc/shadow
++ /etc/group
+- /etc/users
+- /etc/user.conf
+- /etc/inittab
+- /etc/u/u.conf


### PR DESCRIPTION
Add new script for adding questions. This is to be used in offlne mode only, for adding questions inside the game.

Below is the sample run for adding a set of 18 questions in the quiz category, tag name `Matematică 1` (derived from file name), proposed by user `mircea.olteanu` and endorsed by user `razvan.deaconescu`.

    (sandbox)wouso@csapcs:~/wouso.git/wouso$ python utils/add_questions.py ~/data/tests/matematica/Matematică\ I.txt quiz mircea.olteanu razvan.deaconescu
    Import questions from file /home/wouso/data/tests/matematica/Matematică I.txt.
      Category: quiz
      Tag: Matematică I
      Proposed by: mircea.olteanu
      Endorsed by: razvan.deaconescu
    Added question id 303.
    Added question id 304.
    Added question id 305.
    Added question id 306.
    Added question id 307.
    Added question id 308.
    Added question id 309.
    Added question id 310.
    Added question id 311.
    Added question id 312.
    Added question id 313.
    Added question id 314.
    Added question id 315.
    Added question id 316.
    Added question id 317.
    Added question id 318.
    Added question id 319.
    Added question id 320.
    
    Imported 18 questions